### PR TITLE
Updates for MP api

### DIFF
--- a/src/main/java/org/radarcns/managementportal/MpClient.java
+++ b/src/main/java/org/radarcns/managementportal/MpClient.java
@@ -286,13 +286,13 @@ public class MpClient {
     /**
      * Retrieves a {@link Project} from the Management Portal using {@link ServletContext} entity.
      * @param context {@link ServletContext} that has been used to authenticate token
-     * @param projectId {@link String} of the Project that has to be retrieved
+     * @param projectName {@link String} of the Project that has to be retrieved
      * @return {@link Project} retrieved from the Management Portal
      */
-    public Project getProject(String projectId, ServletContext context) throws
+    public Project getProject(String projectName, ServletContext context) throws
             MalformedURLException, URISyntaxException {
 
-        Request request = getBuilder(getUrl(Properties.getProjectEndPoint(), projectId),
+        Request request = getBuilder(getUrl(Properties.getProjectEndPoint(), projectName),
                 context).get().build();
 
         try (Response response = HttpClientListener.getClient(context)

--- a/src/main/java/org/radarcns/webapp/ManagementPortalEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/ManagementPortalEndPoint.java
@@ -51,7 +51,7 @@ public class ManagementPortalEndPoint {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ManagementPortalEndPoint.class);
 
-    private static final String PROJECT_ID = "projectId";
+    private static final String PROJECT_NAME = "projectName";
 
     @Context
     private ServletContext context;
@@ -194,7 +194,7 @@ public class ManagementPortalEndPoint {
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("/" + PROJECT + "/{" + PROJECT_ID + "}")
+    @Path("/" + PROJECT + "/{" + PROJECT_NAME + "}")
     @ApiOperation(
             value = "Return the information related to given subject identifier",
             notes = "Some information are not implemented yet. The returned values are hardcoded.")
@@ -206,11 +206,11 @@ public class ManagementPortalEndPoint {
             @ApiResponse(code = 200, message = "Return the subject.avsc object associated with the "
                     + "given subject identifier")})
     public Response getProjectJson(
-            @PathParam(PROJECT_ID) String projectId
+            @PathParam(PROJECT_NAME) String projectName
     ) {
         try {
             MpClient mpClient = new MpClient(context);
-            Project project = mpClient.getProject(projectId, context);
+            Project project = mpClient.getProject(projectName, context);
             Response response = MpClient.getJsonResponse(project);
             LOGGER.info("Response : " + response.toString());
             return response;


### PR DESCRIPTION
Projects api in MP now requires projectName instead of ID. The ID already had type String. But to avoid confusion in the future the variable names were changed to reflect projectName instead of projectId.