### PR TITLE
Content negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By default, log messages are redirected to the `STDOUT`.
 
 The api documentation is located at `<your-server-address>:<port>/radar/api/swagger.json`
 
-For accessing the end-points of this API, you will need JWT tokens from the [Management Portal](https://github.com/RADAR-CNS/ManagementPortal) and sned it with each request in the header. In order for your token to allow access to the Rest-Api you will need to add the resource name of rest-api (ie - `res_RestApi`) in the oauth client details of the Management Portal(MP). For example, if you want a client named `dashboard` to have access to the REST API just add this line to the OAuth client credentials csv file of MP - 
+For accessing the end-points of this API, you will need JWT tokens from the [Management Portal](https://github.com/RADAR-CNS/ManagementPortal) and send it with each request in the header. In order for your token to allow access to the Rest-Api you will need to add the resource name of rest-api (ie - `res_RestApi`) in the oauth client details of the Management Portal(MP). For example, if you want a client named `dashboard` to have access to the REST API just add this line to the OAuth client credentials csv file of MP - 
 ```
 dashbard;res_RestApi;my-secret-token-to-change-in-production;SUBJECT.READ,PROJECT.READ,SOURCE.READ,DEVICETYPE.READ;client_credentials;;;1800;3600;{};true
 ```

--- a/src/endToEndTest/java/org/radarcns/pipeline/EndToEndTest.java
+++ b/src/endToEndTest/java/org/radarcns/pipeline/EndToEndTest.java
@@ -22,7 +22,7 @@ import static org.radarcns.integration.testcase.config.ExposedConfigTest.CONFIG_
 import static org.radarcns.integration.testcase.config.ExposedConfigTest.getSwaggerBasePath;
 import static org.radarcns.integration.util.WiremockUtils.initializeWiremock;
 import static org.radarcns.integration.util.WiremockUtils.wiremockInitialized;
-import static org.radarcns.webapp.util.BasePath.AVRO;
+import static org.radarcns.webapp.util.BasePath.AVRO_BINARY;
 import static org.radarcns.webapp.util.BasePath.DATA;
 import static org.radarcns.webapp.util.Parameter.INTERVAL;
 import static org.radarcns.webapp.util.Parameter.SENSOR;
@@ -341,7 +341,7 @@ public class EndToEndTest {
             NoSuchAlgorithmException {
         LOGGER.info("Fetching APIs ...");
 
-        String path = DATA + "/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{"
+        String path = DATA + "/{" + SENSOR + "}/{" + STAT + "}/{"
                 + INTERVAL + "}/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", USER_ID_MOCK);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE_ID_MOCK);
@@ -364,6 +364,7 @@ public class EndToEndTest {
                     Request request = new Request.Builder().
                             header("Authorization","Bearer "
                                     + TokenTestUtils.VALID_TOKEN)
+                            .addHeader("Accept", AVRO_BINARY)
                             .url(client.getRelativeUrl(pathSensor)).build();
 
                     try (Response response = client.request(request)) {

--- a/src/integrationTest/java/org/radarcns/integration/testcase/config/ExposedConfigTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/config/ExposedConfigTest.java
@@ -73,7 +73,8 @@ public class ExposedConfigTest {
             throws IOException, NoSuchAlgorithmException, KeyManagementException {
         URL url = new URL(PROTOCOL, SERVER, PORT, "/" + WEB_ROOT + "/" + FRONTEND + "/");
 
-        try (Response response = Utility.makeRequest(new URL(url, CONFIG_JSON).toString())) {
+        try (Response response = Utility.makeRequest(new URL(url, CONFIG_JSON).toString(),
+                "*/*")) {
             assertEquals(200, response.code());
 
             String expected = Utility.readAll(

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/AppStatusEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/AppStatusEndPointTest.java
@@ -20,9 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.radarcns.avro.restapi.header.DescriptiveStatistic.COUNT;
 import static org.radarcns.avro.restapi.sensor.SensorType.HEART_RATE;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.ANDROID;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.STATUS;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.SOURCE_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -64,7 +62,7 @@ public class AppStatusEndPointTest {
 
     @Test
     public void getStatusTest204() throws IOException {
-        String path = ANDROID + "/" + AVRO + "/" + STATUS + "/{" + SUBJECT_ID
+        String path = ANDROID + "/" + STATUS + "/{" + SUBJECT_ID
                 + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE);
@@ -72,7 +70,7 @@ public class AppStatusEndPointTest {
         LOGGER.info(path);
 
         assertEquals(Status.NO_CONTENT.getStatusCode(), Utility.makeRequest(
-                Properties.getApiConfig().getApiUrl() + path).code());
+                Properties.getApiConfig().getApiUrl() + path, AVRO_BINARY).code());
     }
 
     @Test
@@ -96,14 +94,15 @@ public class AppStatusEndPointTest {
 
         Application expected = Utility.convertDocToApplication(map);
 
-        String path = ANDROID + "/" + AVRO + "/" + STATUS + "/{"
+        String path = ANDROID + "/" + STATUS + "/{"
                 + SUBJECT_ID + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT.concat("1"));
         path = path.replace("{" + SOURCE_ID + "}", SOURCE.concat("1"));
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         if (response.code() == Status.OK.getStatusCode()) {

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SensorEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SensorEndPointTest.java
@@ -21,9 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.radarcns.avro.restapi.header.DescriptiveStatistic.COUNT;
 import static org.radarcns.avro.restapi.sensor.SensorType.HEART_RATE;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.DATA;
-import static org.radarcns.webapp.util.BasePath.REALTIME;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.END;
 import static org.radarcns.webapp.util.Parameter.INTERVAL;
 import static org.radarcns.webapp.util.Parameter.SENSOR;
@@ -73,7 +71,7 @@ public class SensorEndPointTest {
     @Test
     public void getRealtimeTest()
             throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = DATA + "/" + AVRO + "/" + REALTIME + "/{" + SENSOR + "}/{" + STAT
+        String path = DATA + "/" + REALTIME + "/{" + SENSOR + "}/{" + STAT
                 + "}/{" + INTERVAL + "}/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SENSOR + "}", SENSOR_TYPE.name());
         path = path.replace("{" + STAT + "}", COUNT.name());
@@ -100,7 +98,8 @@ public class SensorEndPointTest {
 
         Dataset actual = null;
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         if (response.code() == Status.OK.getStatusCode()) {
@@ -116,7 +115,7 @@ public class SensorEndPointTest {
     @Test
     public void getAllByUserTest()
             throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = DATA + "/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
+        String path = DATA + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
                 + SUBJECT_ID + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SENSOR + "}", SENSOR_TYPE.name());
         path = path.replace("{" + STAT + "}", COUNT.name());
@@ -143,7 +142,8 @@ public class SensorEndPointTest {
 
         Dataset actual = null;
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         if (response.code() == Status.OK.getStatusCode()) {
@@ -159,7 +159,7 @@ public class SensorEndPointTest {
     @Test
     public void getTimeWindowTest200()
             throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = DATA + "/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
+        String path = DATA + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
                 + SUBJECT_ID + "}/{" + SOURCE_ID + "}/{" + START + "}/{" + END + "}";
         path = path.replace("{" + SENSOR + "}", SENSOR_TYPE.name());
         path = path.replace("{" + STAT + "}", COUNT.name());
@@ -197,7 +197,8 @@ public class SensorEndPointTest {
 
         Dataset actual = null;
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         if (response.code() == Status.OK.getStatusCode()) {
@@ -213,7 +214,7 @@ public class SensorEndPointTest {
     @Test
     public void getAllDataTest204()
         throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = DATA + "/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
+        String path = DATA + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{"
                 + SUBJECT_ID + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SENSOR + "}", SENSOR_TYPE.name());
         path = path.replace("{" + STAT + "}", COUNT.name());
@@ -223,7 +224,8 @@ public class SensorEndPointTest {
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.NO_CONTENT.getStatusCode(), response.code());
     }
 

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SourceEndPointTest.java
@@ -6,10 +6,7 @@ import static org.radarcns.avro.restapi.sensor.SensorType.HEART_RATE;
 import static org.radarcns.avro.restapi.source.SourceType.ANDROID;
 import static org.radarcns.avro.restapi.source.SourceType.BIOVOTION;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.GET_ALL_SOURCES;
-import static org.radarcns.webapp.util.BasePath.SPECIFICATION;
-import static org.radarcns.webapp.util.BasePath.STATE;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.SOURCE_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -42,7 +39,6 @@ import org.radarcns.integration.util.RandomInput;
 import org.radarcns.integration.util.Utility;
 import org.radarcns.monitor.Monitors;
 import org.radarcns.util.AvroConverter;
-import org.radarcns.webapp.util.BasePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +71,7 @@ public class SourceEndPointTest {
 
     @Test
     public void getStatusTest204() throws IOException {
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + STATE + "/{" + SUBJECT_ID
+        String path = SOURCE + "/" + STATE + "/{" + SUBJECT_ID
                 + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE);
@@ -83,7 +79,7 @@ public class SourceEndPointTest {
         LOGGER.info(path);
 
         assertEquals(Status.NO_CONTENT.getStatusCode(), Utility.makeRequest(
-                Properties.getApiConfig().getApiUrl() + path).code());
+                Properties.getApiConfig().getApiUrl() + path, AVRO_BINARY).code());
     }
 
     @Test
@@ -94,14 +90,15 @@ public class SourceEndPointTest {
 
         MongoDataAccess.writeSourceType(SOURCE, SOURCE_TYPE, client);
 
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + STATE + "/{" + SUBJECT_ID
+        String path = SOURCE + "/" + STATE + "/{" + SUBJECT_ID
                 + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE);
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         byte[] array = response.body().bytes();
@@ -142,23 +139,24 @@ public class SourceEndPointTest {
 
     @Test
     public void getSpecificationTest500() throws IOException {
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
+        String path = SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
         path = path.replace("{" + SOURCE_TYPE + "}", BIOVOTION.toString());
 
         LOGGER.info(path);
 
         assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), Utility.makeRequest(
-                Properties.getApiConfig().getApiUrl() + path).code());
+                Properties.getApiConfig().getApiUrl() + path, AVRO_BINARY).code());
     }
 
     @Test
     public void getSpecificationTest200() throws IOException {
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
+        String path = SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
         path = path.replace("{" + SOURCE_TYPE + "}", EMPATICA.toString());
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         SourceSpecification expected = Monitors.getInstance().getSpecification(EMPATICA);
@@ -186,7 +184,7 @@ public class SourceEndPointTest {
     @Test
     public void getAllSourcesTest200()
         throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + GET_ALL_SOURCES
+        String path = SOURCE + "/" + GET_ALL_SOURCES
                 + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 
@@ -203,7 +201,8 @@ public class SourceEndPointTest {
         Utility.insertMixedDocs(client,
                 RandomInput.getRandomApplicationStatus(SUBJECT, SOURCE.concat("1")));
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         Subject actual = null;
@@ -235,13 +234,14 @@ public class SourceEndPointTest {
     @Test
     public void getAllSourcesTest204()
         throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = BasePath.SOURCE + "/" + AVRO + "/" + GET_ALL_SOURCES
+        String path = SOURCE + "/" + GET_ALL_SOURCES
                 + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.NO_CONTENT.getStatusCode(), response.code());
     }
 

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SourceEndPointTest.java
@@ -6,7 +6,10 @@ import static org.radarcns.avro.restapi.sensor.SensorType.HEART_RATE;
 import static org.radarcns.avro.restapi.source.SourceType.ANDROID;
 import static org.radarcns.avro.restapi.source.SourceType.BIOVOTION;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.*;
+import static org.radarcns.webapp.util.BasePath.STATE;
+import static org.radarcns.webapp.util.BasePath.SPECIFICATION;
+import static org.radarcns.webapp.util.BasePath.AVRO_BINARY;
+import static org.radarcns.webapp.util.BasePath.GET_ALL_SOURCES;
 import static org.radarcns.webapp.util.Parameter.SOURCE_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -39,6 +42,7 @@ import org.radarcns.integration.util.RandomInput;
 import org.radarcns.integration.util.Utility;
 import org.radarcns.monitor.Monitors;
 import org.radarcns.util.AvroConverter;
+import org.radarcns.webapp.util.BasePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +75,7 @@ public class SourceEndPointTest {
 
     @Test
     public void getStatusTest204() throws IOException {
-        String path = SOURCE + "/" + STATE + "/{" + SUBJECT_ID
+        String path = BasePath.SOURCE + "/" + STATE + "/{" + SUBJECT_ID
                 + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE);
@@ -90,7 +94,7 @@ public class SourceEndPointTest {
 
         MongoDataAccess.writeSourceType(SOURCE, SOURCE_TYPE, client);
 
-        String path = SOURCE + "/" + STATE + "/{" + SUBJECT_ID
+        String path = BasePath.SOURCE + "/" + STATE + "/{" + SUBJECT_ID
                 + "}/{" + SOURCE_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
         path = path.replace("{" + SOURCE_ID + "}", SOURCE);
@@ -139,7 +143,7 @@ public class SourceEndPointTest {
 
     @Test
     public void getSpecificationTest500() throws IOException {
-        String path = SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
+        String path = BasePath.SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
         path = path.replace("{" + SOURCE_TYPE + "}", BIOVOTION.toString());
 
         LOGGER.info(path);
@@ -150,7 +154,7 @@ public class SourceEndPointTest {
 
     @Test
     public void getSpecificationTest200() throws IOException {
-        String path = SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
+        String path = BasePath.SOURCE + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}";
         path = path.replace("{" + SOURCE_TYPE + "}", EMPATICA.toString());
 
         LOGGER.info(path);
@@ -184,7 +188,7 @@ public class SourceEndPointTest {
     @Test
     public void getAllSourcesTest200()
         throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = SOURCE + "/" + GET_ALL_SOURCES
+        String path = BasePath.SOURCE + "/" + GET_ALL_SOURCES
                 + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 
@@ -234,7 +238,7 @@ public class SourceEndPointTest {
     @Test
     public void getAllSourcesTest204()
         throws IOException, IllegalAccessException, InstantiationException, URISyntaxException {
-        String path = SOURCE + "/" + GET_ALL_SOURCES
+        String path = BasePath.SOURCE + "/" + GET_ALL_SOURCES
                 + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
@@ -28,7 +28,7 @@ import static org.radarcns.avro.restapi.sensor.SensorType.THERMOMETER;
 import static org.radarcns.avro.restapi.source.SourceType.ANDROID;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
 import static org.radarcns.webapp.util.BasePath.AVRO_BINARY;
-import static org.radarcns.webapp.util.BasePath.GET_ALL_SUBJECTS;git
+import static org.radarcns.webapp.util.BasePath.GET_ALL_SUBJECTS;
 import static org.radarcns.webapp.util.BasePath.GET_SUBJECT;
 
 import static org.radarcns.webapp.util.Parameter.STUDY_ID;

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
@@ -27,9 +27,7 @@ import static org.radarcns.avro.restapi.sensor.SensorType.INTER_BEAT_INTERVAL;
 import static org.radarcns.avro.restapi.sensor.SensorType.THERMOMETER;
 import static org.radarcns.avro.restapi.source.SourceType.ANDROID;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.GET_ALL_SUBJECTS;
-import static org.radarcns.webapp.util.BasePath.GET_SUBJECT;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.STUDY_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -61,7 +59,6 @@ import org.radarcns.dao.mongo.util.MongoHelper;
 import org.radarcns.integration.util.RandomInput;
 import org.radarcns.integration.util.Utility;
 import org.radarcns.util.AvroConverter;
-import org.radarcns.webapp.util.BasePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,14 +75,14 @@ public class SubjectEndPointTest {
 
     @Test
     public void getAllSubjectsTest204() throws IOException {
-        String path = BasePath.SUBJECT + "/" + AVRO + "/" + GET_ALL_SUBJECTS + "/{"
+        String path = SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
                 + STUDY_ID + "}";
         path = path.replace("{" + STUDY_ID + "}", "0");
 
         LOGGER.info(path);
 
         assertEquals(Status.NO_CONTENT.getStatusCode(), Utility.makeRequest(
-                Properties.getApiConfig().getApiUrl() + path).code());
+                Properties.getApiConfig().getApiUrl() + path, AVRO_BINARY).code());
     }
 
     @Test
@@ -103,13 +100,14 @@ public class SubjectEndPointTest {
         Utility.insertMixedDocs(client,
                 RandomInput.getRandomApplicationStatus(SUBJECT.concat("1"), SOURCE.concat("1")));
 
-        String path = BasePath.SUBJECT + "/" + AVRO + "/" + GET_ALL_SUBJECTS + "/{"
+        String path = SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
                 + STUDY_ID + "}";
         path = path.replace("{" + STUDY_ID + "}", "0");
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         byte[] array = response.body().bytes();
@@ -135,13 +133,13 @@ public class SubjectEndPointTest {
 
     @Test
     public void getSubjectTest204() throws IOException {
-        String path = BasePath.SUBJECT + "/" + AVRO + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
+        String path = SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", "0");
 
         LOGGER.info(path);
 
         assertEquals(Status.NO_CONTENT.getStatusCode(), Utility.makeRequest(
-                Properties.getApiConfig().getApiUrl() + path).code());
+                Properties.getApiConfig().getApiUrl() + path, AVRO_BINARY).code());
     }
 
     @Test
@@ -159,12 +157,13 @@ public class SubjectEndPointTest {
 
         collection.insertMany(randomInput);
 
-        String path = BasePath.SUBJECT + "/" + AVRO + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
+        String path = SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 
         LOGGER.info(path);
 
-        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path);
+        Response response = Utility.makeRequest(Properties.getApiConfig().getApiUrl() + path,
+                AVRO_BINARY);
         assertEquals(Status.OK.getStatusCode(), response.code());
 
         if (response.code() == Status.OK.getStatusCode()) {

--- a/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/integration/testcase/webapp/SubjectEndPointTest.java
@@ -27,7 +27,10 @@ import static org.radarcns.avro.restapi.sensor.SensorType.INTER_BEAT_INTERVAL;
 import static org.radarcns.avro.restapi.sensor.SensorType.THERMOMETER;
 import static org.radarcns.avro.restapi.source.SourceType.ANDROID;
 import static org.radarcns.avro.restapi.source.SourceType.EMPATICA;
-import static org.radarcns.webapp.util.BasePath.*;
+import static org.radarcns.webapp.util.BasePath.AVRO_BINARY;
+import static org.radarcns.webapp.util.BasePath.GET_ALL_SUBJECTS;git
+import static org.radarcns.webapp.util.BasePath.GET_SUBJECT;
+
 import static org.radarcns.webapp.util.Parameter.STUDY_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -59,6 +62,7 @@ import org.radarcns.dao.mongo.util.MongoHelper;
 import org.radarcns.integration.util.RandomInput;
 import org.radarcns.integration.util.Utility;
 import org.radarcns.util.AvroConverter;
+import org.radarcns.webapp.util.BasePath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +79,7 @@ public class SubjectEndPointTest {
 
     @Test
     public void getAllSubjectsTest204() throws IOException {
-        String path = SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
+        String path = BasePath.SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
                 + STUDY_ID + "}";
         path = path.replace("{" + STUDY_ID + "}", "0");
 
@@ -100,7 +104,7 @@ public class SubjectEndPointTest {
         Utility.insertMixedDocs(client,
                 RandomInput.getRandomApplicationStatus(SUBJECT.concat("1"), SOURCE.concat("1")));
 
-        String path = SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
+        String path = BasePath.SUBJECT + "/" + GET_ALL_SUBJECTS + "/{"
                 + STUDY_ID + "}";
         path = path.replace("{" + STUDY_ID + "}", "0");
 
@@ -133,7 +137,7 @@ public class SubjectEndPointTest {
 
     @Test
     public void getSubjectTest204() throws IOException {
-        String path = SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
+        String path = BasePath.SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", "0");
 
         LOGGER.info(path);
@@ -157,7 +161,7 @@ public class SubjectEndPointTest {
 
         collection.insertMany(randomInput);
 
-        String path = SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
+        String path = BasePath.SUBJECT + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}";
         path = path.replace("{" + SUBJECT_ID + "}", SUBJECT);
 
         LOGGER.info(path);

--- a/src/integrationTest/java/org/radarcns/integration/util/Utility.java
+++ b/src/integrationTest/java/org/radarcns/integration/util/Utility.java
@@ -160,11 +160,12 @@ public class Utility {
      * Makes an HTTP request to given URL.
      *
      * @param url end-point
+     * @param accept Accept Header for content negotiation
      *
      * @return HTTP Response
      * @throws IOException if the request could not be executed
      */
-    public static Response makeRequest(String url) throws IOException {
+    public static Response makeRequest(String url, String accept) throws IOException {
         OkHttpClient client = new OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .writeTimeout(30, TimeUnit.SECONDS)
@@ -173,6 +174,7 @@ public class Utility {
 
         Request request = new Request.Builder()
                 .addHeader("User-Agent", "Mozilla/5.0")
+                .addHeader("Accept", accept)
                 .header("Authorization","Bearer " + TokenTestUtils.VALID_TOKEN)
                 .url(url)
                 .build();

--- a/src/main/java/org/radarcns/webapp/AppStatusEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/AppStatusEndPoint.java
@@ -19,9 +19,7 @@ package org.radarcns.webapp;
 import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
 import static org.radarcns.security.utils.SecurityUtils.getJWT;
-import static org.radarcns.webapp.util.BasePath.ANDROID;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.STATUS;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.SOURCE_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -112,8 +110,8 @@ public class AppStatusEndPoint {
      * AVRO function that returns the status app of the given subject.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + STATUS + "/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + STATUS + "/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}")
     @ApiOperation(
             value = "Return an Applications status",
             notes = "The Android application periodically updates its current status")

--- a/src/main/java/org/radarcns/webapp/SensorEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/SensorEndPoint.java
@@ -19,9 +19,7 @@ package org.radarcns.webapp;
 import static org.radarcns.auth.authorization.Permission.MEASUREMENT_READ;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
 import static org.radarcns.security.utils.SecurityUtils.getJWT;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.DATA;
-import static org.radarcns.webapp.util.BasePath.REALTIME;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.END;
 import static org.radarcns.webapp.util.Parameter.INTERVAL;
 import static org.radarcns.webapp.util.Parameter.SENSOR;
@@ -130,8 +128,8 @@ public class SensorEndPoint {
      * AVRO function that returns the last seen data value if available.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + REALTIME + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL
+    @Produces(AVRO_BINARY)
+    @Path("/" + REALTIME + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL
             + "}/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}")
     @ApiOperation(
             value = "Returns a dataset object formatted in Apache AVRO.",
@@ -250,8 +248,8 @@ public class SensorEndPoint {
      * AVRO function that returns all available samples for the given data.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{" + SUBJECT_ID + "}/{"
+    @Produces(AVRO_BINARY)
+    @Path("/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{" + SUBJECT_ID + "}/{"
             + SOURCE_ID + "}")
     @ApiOperation(
             value = "Returns a dataset object formatted in Apache AVRO.",
@@ -373,8 +371,8 @@ public class SensorEndPoint {
      * AVRO function that returns all data value inside the time-window [start-end].
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{" + SUBJECT_ID + "}/{"
+    @Produces(AVRO_BINARY)
+    @Path("/{" + SENSOR + "}/{" + STAT + "}/{" + INTERVAL + "}/{" + SUBJECT_ID + "}/{"
             + SOURCE_ID + "}/{" + START + "}/{" + END + "}")
     @ApiOperation(
             value = "Returns a dataset object formatted in Apache AVRO.",

--- a/src/main/java/org/radarcns/webapp/SourceEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/SourceEndPoint.java
@@ -20,11 +20,7 @@ import static org.radarcns.auth.authorization.Permission.SOURCE_READ;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
 import static org.radarcns.security.utils.SecurityUtils.getJWT;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.GET_ALL_SOURCES;
-import static org.radarcns.webapp.util.BasePath.SOURCE;
-import static org.radarcns.webapp.util.BasePath.SPECIFICATION;
-import static org.radarcns.webapp.util.BasePath.STATE;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.SOURCE_ID;
 import static org.radarcns.webapp.util.Parameter.SOURCE_TYPE;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
@@ -120,8 +116,8 @@ public class SourceEndPoint {
      * AVRO function that returns the status of the given source.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + STATE + "/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + STATE + "/{" + SUBJECT_ID + "}/{" + SOURCE_ID + "}")
     @ApiOperation(
             value = "Return a SourceDefinition values",
             notes = "Using the source sensors values arrived within last 60sec, it computes the"
@@ -218,8 +214,8 @@ public class SourceEndPoint {
      * AVRO function that returns the status of the given data.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + SPECIFICATION + "/{" + SOURCE_TYPE + "}")
     @ApiOperation(
             value = "Return a SourceDefinition specification",
             notes = "Return the data specification of all on-board sensors for the given"
@@ -305,8 +301,8 @@ public class SourceEndPoint {
      * AVRO function that returns all known sources for the given subject.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + GET_ALL_SOURCES + "/{" + SUBJECT_ID + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + GET_ALL_SOURCES + "/{" + SUBJECT_ID + "}")
     @ApiOperation(
             value = "Return a User value",
             notes = "Return all known sources associated with the give subjectID")

--- a/src/main/java/org/radarcns/webapp/SubjectEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/SubjectEndPoint.java
@@ -20,10 +20,7 @@ import static org.radarcns.auth.authorization.Permission.SUBJECT_READ;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermission;
 import static org.radarcns.auth.authorization.RadarAuthorization.checkPermissionOnProject;
 import static org.radarcns.security.utils.SecurityUtils.getJWT;
-import static org.radarcns.webapp.util.BasePath.AVRO;
-import static org.radarcns.webapp.util.BasePath.GET_ALL_SUBJECTS;
-import static org.radarcns.webapp.util.BasePath.GET_SUBJECT;
-import static org.radarcns.webapp.util.BasePath.SUBJECT;
+import static org.radarcns.webapp.util.BasePath.*;
 import static org.radarcns.webapp.util.Parameter.STUDY_ID;
 import static org.radarcns.webapp.util.Parameter.SUBJECT_ID;
 
@@ -109,8 +106,8 @@ public class SubjectEndPoint {
      * AVRO function that returns all available subject.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + GET_ALL_SUBJECTS + "/{" + STUDY_ID + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + GET_ALL_SUBJECTS + "/{" + STUDY_ID + "}")
     @ApiOperation(
             value = "Return a list of subjects",
             notes = "Each subject can have multiple sourceID associated with him")
@@ -195,8 +192,8 @@ public class SubjectEndPoint {
      * AVRO function that returns all information related to the given subject identifier.
      */
     @GET
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @Path("/" + AVRO + "/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}")
+    @Produces(AVRO_BINARY)
+    @Path("/" + GET_SUBJECT + "/{" + SUBJECT_ID + "}")
     @ApiOperation(
             value = "Return the information related to given subject identifier",
             notes = "Some information are not implemented yet. The returned values are hardcoded.")

--- a/src/main/java/org/radarcns/webapp/util/BasePath.java
+++ b/src/main/java/org/radarcns/webapp/util/BasePath.java
@@ -35,6 +35,7 @@ public class BasePath {
     public static final String STATE = "state";
     public static final String PROJECT = "projects";
     public static final String SUBJECTS = "subjects";
+    public static final String AVRO_BINARY = "avro/binary";
 
 
     private BasePath() {


### PR DESCRIPTION
- Add content negotiation instead of using different paths for JSON and AVRO
- Changed `@Producer` media type from  `application/octet-stream` to `avro/binary` for AVRO based methods
- Updated tests to include content negotiation
- Closes #40 
- Depends on #49 