### PR TITLE
Compute source status 

### DIFF
--- a/radar.yml
+++ b/radar.yml
@@ -24,7 +24,7 @@ management_portal_config:
 # Timeout duration for every source-type to decide source status whether its connected or not.
 # A source-type should be defined by following the convention of producer_model as mentioned in
 # the specification in radar-schemas
-# timeout should be specified as {@code PnDTnHnMn.nS}.
+# timeout should be specified as the ISO-8601 duration format {@code PnDTnHnMn.nS}.
 source-type-connection-timeout:
-    android_phone: 2H
-    empatica_e4: 1H
+    android_phone: PT2H
+    empatica_e4: PT1H

--- a/radar.yml
+++ b/radar.yml
@@ -20,3 +20,11 @@ management_portal_config:
     source_type_endpoint: api/source-types/
     source_data_endpoint: api/source-data/
     source_endpoint: api/sources/
+
+# Timeout duration for every source-type to decide source status whether its connected or not.
+# A source-type should be defined by following the convention of producer_model as mentioned in
+# the specification in radar-schemas
+# timeout should be specified as {@code PnDTnHnMn.nS}.
+source-type-connection-timeout:
+    android_phone: 2H
+    empatica_e4: 1H

--- a/src/integrationTest/java/org/radarcns/webapp/SampleDataHandler.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SampleDataHandler.java
@@ -20,4 +20,5 @@ public interface SampleDataHandler {
     String PRODUCER = "Empatica";
     String MODEL = "E4";
     String CATALOGUE_VERSION = "v1";
+    String MONITOR_STATISTICS_TOPIC = "source_statistics_empatica_e4";
 }

--- a/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
@@ -17,9 +17,13 @@
 package org.radarcns.webapp;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.radarcns.integration.util.ExpectedDocumentFactory.getDocumentsForStatistics;
+import static org.radarcns.webapp.SampleDataHandler.MONITOR_STATISTICS_TOPIC;
 import static org.radarcns.webapp.SampleDataHandler.PROJECT;
+import static org.radarcns.webapp.SampleDataHandler.SOURCE;
 import static org.radarcns.webapp.SampleDataHandler.SUBJECT;
 import static org.radarcns.webapp.resource.BasePath.PROJECTS;
 import static org.radarcns.webapp.resource.BasePath.SOURCES;
@@ -27,17 +31,25 @@ import static org.radarcns.webapp.resource.BasePath.SUBJECTS;
 
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import javax.ws.rs.core.Response.Status;
 import okhttp3.Response;
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.radarcns.domain.restapi.Source;
+import org.radarcns.domain.restapi.SourceStatus;
 import org.radarcns.integration.util.ApiClient;
 import org.radarcns.integration.util.RestApiDetails;
 import org.radarcns.integration.util.Utility;
+import org.radarcns.mongo.util.MongoHelper;
 import org.radarcns.util.RadarConverter;
 
 public class SourceEndPointTest {
@@ -49,6 +61,62 @@ public class SourceEndPointTest {
 
     @Test
     public void getAllSourcesForSubjectInProject() throws IOException {
+        List<Source> sources = requestSourcesOfSubject();
+        // not effective time available
+        assertEquals(SourceStatus.UNKNOWN, sources.get(0).getStatus());
+    }
+
+    @Test
+    public void getAllSourcesForSubjectInProjectDisconnected() throws IOException {
+        Instant now = Instant.now();
+        insertMonitorStatistics(now.minus(Duration.ofDays(2)), now.minus(Duration.ofHours(20)));
+
+        List<Source> sources = requestSourcesOfSubject();
+        assertEquals(SourceStatus.DISCONNECTED, sources.get(0).getStatus());
+    }
+
+    @Test
+    public void getAllSourcesForSubjectInProjectConnected() throws IOException {
+        Instant now = Instant.now();
+        insertMonitorStatistics(now.minus(Duration.ofMinutes(30)), now);
+
+        // not effective time available
+        List<Source> sources = requestSourcesOfSubject();
+        assertEquals(SourceStatus.CONNECTED, sources.get(0).getStatus());
+    }
+
+    @Test
+    public void getSourceByIdConnected() throws IOException {
+        Instant now = Instant.now();
+        insertMonitorStatistics(now.minus(Duration.ofMinutes(30)), now);
+
+        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
+                + SOURCES + '/' + SOURCE;
+        try (Response response = apiClient.request(requestPath, APPLICATION_JSON, Status.OK)) {
+            assertNotNull(response);
+            assertTrue(response.isSuccessful());
+
+            ObjectReader reader = RadarConverter.readerFor(Source.class);
+            Source sources = reader.readValue(response.body().byteStream());
+            assertNotNull(sources);
+            assertEquals(SourceStatus.CONNECTED, sources.getStatus());
+        }
+    }
+
+    @Test
+    public void getSourceByIdInvalidConnected() throws IOException {
+        Instant now = Instant.now();
+        insertMonitorStatistics(now.minus(Duration.ofMinutes(30)), now);
+
+        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
+                + SOURCES + '/' + "something";
+        try (Response response = apiClient
+                .request(requestPath, APPLICATION_JSON, Status.NOT_FOUND)) {
+            assertNotNull(response);
+        }
+    }
+
+    private List<Source> requestSourcesOfSubject() throws IOException {
         String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
                 + SOURCES;
         try (Response response = apiClient.request(requestPath, APPLICATION_JSON, Status.OK)) {
@@ -58,20 +126,26 @@ public class SourceEndPointTest {
             ObjectReader reader = RadarConverter.readerForCollection(List.class, Source.class);
             List<Source> sources = reader.readValue(response.body().byteStream());
             assertTrue(sources.size() > 0);
+            return sources;
         }
     }
 
-    @After
-    public void dropAndClose() {
-        dropAndClose(Utility.getMongoClient());
+    private void insertMonitorStatistics(Instant startTime, Instant end) {
+        MongoClient mongoClient = Utility.getMongoClient();
+        Document doc = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, Date.from(startTime),
+                Date.from(end));
+        Document second = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, Date.from(startTime),
+                Date.from(end.plus(Duration.ofMinutes(5))));
+        MongoCollection collection = MongoHelper
+                .getCollection(mongoClient, MONITOR_STATISTICS_TOPIC);
+        collection.insertMany(Arrays.asList(doc, second));
     }
 
-    /**
-     * Drops all used collections to bring the database back to the initial state, and close the
-     * database connection.
-     **/
-    public void dropAndClose(MongoClient client) {
-        client.close();
+
+    @After
+    public void dropAndClose() {
+        Utility.dropCollection(Utility.getMongoClient(), MONITOR_STATISTICS_TOPIC);
     }
+
 
 }

--- a/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
@@ -16,6 +16,7 @@
 
 package org.radarcns.webapp;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import org.radarcns.domain.restapi.Source;
 import org.radarcns.integration.MongoRule;
 import org.radarcns.integration.util.ApiClient;
 import org.radarcns.integration.util.RestApiDetails;
+import org.radarcns.webapp.resource.BasePath;
 
 public class SourceEndPointTest {
 
@@ -100,12 +102,9 @@ public class SourceEndPointTest {
 
     @Test
     public void getSourceByIdInvalidConnected() throws IOException {
-        Instant now = Instant.now();
-        insertMonitorStatistics(now.minus(Duration.ofMinutes(30)), now);
-
-        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
-                + SOURCES + '/' + "something";
-        apiClient.getJson(requestPath, Source.class, Status.NOT_FOUND);
+        assertNotNull(apiClient.get(PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
+                        + SOURCES + '/' +"OTHER",
+                APPLICATION_JSON, Status.NOT_FOUND));
     }
 
 

--- a/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
@@ -45,7 +45,6 @@ import org.radarcns.domain.restapi.Source;
 import org.radarcns.integration.MongoRule;
 import org.radarcns.integration.util.ApiClient;
 import org.radarcns.integration.util.RestApiDetails;
-import org.radarcns.webapp.resource.BasePath;
 
 public class SourceEndPointTest {
 
@@ -103,7 +102,7 @@ public class SourceEndPointTest {
     @Test
     public void getSourceByIdInvalidConnected() throws IOException {
         assertNotNull(apiClient.get(PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
-                        + SOURCES + '/' +"OTHER",
+                        + SOURCES + '/' + "OTHER",
                 APPLICATION_JSON, Status.NOT_FOUND));
     }
 

--- a/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SourceEndPointTest.java
@@ -16,26 +16,39 @@
 
 package org.radarcns.webapp;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.radarcns.domain.restapi.SourceStatus.CONNECTED;
+import static org.radarcns.domain.restapi.SourceStatus.DISCONNECTED;
+import static org.radarcns.integration.util.ExpectedDocumentFactory.getDocumentsForStatistics;
+import static org.radarcns.webapp.SampleDataHandler.MONITOR_STATISTICS_TOPIC;
 import static org.radarcns.webapp.SampleDataHandler.PROJECT;
+import static org.radarcns.webapp.SampleDataHandler.SOURCE;
 import static org.radarcns.webapp.SampleDataHandler.SUBJECT;
 import static org.radarcns.webapp.resource.BasePath.PROJECTS;
 import static org.radarcns.webapp.resource.BasePath.SOURCES;
 import static org.radarcns.webapp.resource.BasePath.SUBJECTS;
 
+import com.mongodb.client.MongoCollection;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import javax.ws.rs.core.Response.Status;
+import org.bson.Document;
 import org.junit.Rule;
 import org.junit.Test;
 import org.radarcns.domain.restapi.Source;
+import org.radarcns.integration.MongoRule;
 import org.radarcns.integration.util.ApiClient;
 import org.radarcns.integration.util.RestApiDetails;
 
 public class SourceEndPointTest {
+
+    @Rule
+    public final MongoRule mongoRule = new MongoRule();
 
     @Rule
     public final ApiClient apiClient = new ApiClient(
@@ -55,18 +68,22 @@ public class SourceEndPointTest {
         Instant now = Instant.now();
         insertMonitorStatistics(now.minus(Duration.ofDays(2)), now.minus(Duration.ofHours(20)));
 
-        List<Source> sources = requestSourcesOfSubject();
-        assertEquals(SourceStatus.DISCONNECTED, sources.get(0).getStatus());
+        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
+                + SOURCES;
+
+        List<Source> sources = apiClient.getJsonList(requestPath, Source.class, Status.OK);
+        assertEquals(DISCONNECTED, sources.get(0).getStatus());
     }
 
     @Test
     public void getAllSourcesForSubjectInProjectConnected() throws IOException {
         Instant now = Instant.now();
         insertMonitorStatistics(now.minus(Duration.ofMinutes(30)), now);
+        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
+                + SOURCES;
 
-        // not effective time available
-        List<Source> sources = requestSourcesOfSubject();
-        assertEquals(SourceStatus.CONNECTED, sources.get(0).getStatus());
+        List<Source> sources = apiClient.getJsonList(requestPath, Source.class, Status.OK);
+        assertEquals(CONNECTED, sources.get(0).getStatus());
     }
 
     @Test
@@ -76,15 +93,9 @@ public class SourceEndPointTest {
 
         String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
                 + SOURCES + '/' + SOURCE;
-        try (Response response = apiClient.request(requestPath, APPLICATION_JSON, Status.OK)) {
-            assertNotNull(response);
-            assertTrue(response.isSuccessful());
-
-            ObjectReader reader = RadarConverter.readerFor(Source.class);
-            Source sources = reader.readValue(response.body().byteStream());
-            assertNotNull(sources);
-            assertEquals(SourceStatus.CONNECTED, sources.getStatus());
-        }
+        Source source = apiClient.getJson(requestPath, Source.class, Status.OK);
+        assertNotNull(source);
+        assertEquals(CONNECTED, source.getStatus());
     }
 
     @Test
@@ -94,26 +105,16 @@ public class SourceEndPointTest {
 
         String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
                 + SOURCES + '/' + "something";
-        try (Response response = apiClient
-                .request(requestPath, APPLICATION_JSON, Status.NOT_FOUND)) {
-            assertNotNull(response);
-        }
+        apiClient.getJson(requestPath, Source.class, Status.NOT_FOUND);
     }
 
-    private List<Source> requestSourcesOfSubject() throws IOException {
-        String requestPath = PROJECTS + '/' + PROJECT + '/' + SUBJECTS + '/' + SUBJECT + '/'
-                + SOURCES;
 
-        List<Source> sources = apiClient.getJsonList(requestPath, Source.class, Status.OK);
-        assertTrue(sources.size() > 0);
+    private void insertMonitorStatistics(Instant startTime, Instant end) {
+        Document doc = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, startTime, end);
+        Document second = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, startTime,
+                end.plus(Duration.ofMinutes(5)));
+        MongoCollection<Document> collection = mongoRule.getCollection(MONITOR_STATISTICS_TOPIC);
+        collection.insertMany(Arrays.asList(doc, second));
     }
-
-}
-
-    @After
-    public void dropAndClose() {
-        Utility.dropCollection(Utility.getMongoClient(), MONITOR_STATISTICS_TOPIC);
-    }
-
 
 }

--- a/src/integrationTest/java/org/radarcns/webapp/SubjectEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SubjectEndPointTest.java
@@ -46,8 +46,6 @@ import org.radarcns.webapp.resource.BasePath;
 
 public class SubjectEndPointTest {
 
-    private static final String MONITOR_STATISTICS_TOPIC = "source_statistics_empatica_e4";
-
     @Rule
     public final ApiClient apiClient = new ApiClient(
             RestApiDetails.getRestApiClientDetails().getApplicationConfig().getUrlString());
@@ -69,27 +67,6 @@ public class SubjectEndPointTest {
 
     }
 
-
-    private void insertMonitorStatistics(Instant startTime, Instant end) {
-        MongoClient mongoClient = Utility.getMongoClient();
-        Document doc = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, Date.from(startTime),
-                Date.from(end));
-        Document second = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, Date.from(startTime),
-                Date.from(end.plus(Duration.ofMinutes(5))));
-        MongoCollection collection = MongoHelper
-                .getCollection(mongoClient, MONITOR_STATISTICS_TOPIC);
-        collection.insertMany(Arrays.asList(doc, second));
-    }
-
-    private void insertMonitorStatistics() {
-        Instant start = Instant.now();
-        Instant end = start.plusSeconds(60);
-        Instant later = end.plusSeconds(5);
-        Document doc = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, start, end);
-        Document second = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, start, later);
-        MongoCollection<Document> collection = mongoRule.getCollection(MONITOR_STATISTICS_TOPIC);
-        collection.insertMany(Arrays.asList(doc, second));
-    }
     @Test
     public void getSubjectsBySubjectIdAndProjectName200() throws IOException {
         Instant now = Instant.now();
@@ -120,4 +97,13 @@ public class SubjectEndPointTest {
                 BasePath.PROJECTS + '/' + PROJECT + '/' + SUBJECTS + "/OTHER",
                 APPLICATION_JSON, Status.NOT_FOUND));
     }
+
+    private void insertMonitorStatistics(Instant startTime, Instant end) {
+        Document doc = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, startTime, end);
+        Document second = getDocumentsForStatistics(PROJECT, SUBJECT, SOURCE, startTime,
+                end.plus(Duration.ofMinutes(5)));
+        MongoCollection<Document> collection = mongoRule.getCollection(MONITOR_STATISTICS_TOPIC);
+        collection.insertMany(Arrays.asList(doc, second));
+    }
+
 }

--- a/src/integrationTest/resources/radar.yml
+++ b/src/integrationTest/resources/radar.yml
@@ -22,3 +22,11 @@ management_portal_config:
     source_endpoint: api/sources/
 
 hdfs_output_dir: /var/lib/hdfs/output
+
+# Timeout duration for every source-type to decide source status whether its connected or not.
+# A source-type should be defined by following the convention of producer_model as mentioned in
+# the specification in radar-schemas
+# timeout should be specified as {@code PnDTnHnMn.nS}.
+source-type-connection-timeout:
+    android_phone: 2H
+    empatica_e4: 1H

--- a/src/integrationTest/resources/radar.yml
+++ b/src/integrationTest/resources/radar.yml
@@ -26,7 +26,7 @@ hdfs_output_dir: /var/lib/hdfs/output
 # Timeout duration for every source-type to decide source status whether its connected or not.
 # A source-type should be defined by following the convention of producer_model as mentioned in
 # the specification in radar-schemas
-# timeout should be specified as {@code PnDTnHnMn.nS}.
+# timeout should be specified as the ISO-8601 duration format {@code PnDTnHnMn.nS}.
 source-type-connection-timeout:
-    android_phone: 2H
-    empatica_e4: 1H
+    android_phone: PT2H
+    empatica_e4: PT1H

--- a/src/main/java/org/radarcns/config/ApplicationConfig.java
+++ b/src/main/java/org/radarcns/config/ApplicationConfig.java
@@ -48,6 +48,9 @@ public class ApplicationConfig {
     @JsonProperty("management_portal_config")
     private ManagementPortalConfig managementPortalConfig;
 
+    @JsonProperty("source-type-connection-timeout")
+    private Map<String, String> sourceTypeConnectionTimeout;
+
     /**
      * Returns MongoDb hosts.
      **/
@@ -58,8 +61,9 @@ public class ApplicationConfig {
     /**
      * Sets MongoDb instance.
      **/
-    public void setMongoHosts(Map<String, String> mongoHosts) {
+    public ApplicationConfig mongoHosts(Map<String, String> mongoHosts) {
         this.mongoHosts = mongoHosts;
+        return this;
     }
 
     /**
@@ -72,8 +76,9 @@ public class ApplicationConfig {
     /**
      * Sets MongoDb users.
      **/
-    public void setMongoUser(Map<String, String> mongoUser) {
+    public ApplicationConfig mongoUser(Map<String, String> mongoUser) {
         this.mongoUser = mongoUser;
+        return this;
     }
 
     /**
@@ -118,7 +123,17 @@ public class ApplicationConfig {
         return hdfsOutputDir;
     }
 
-    public void setHdfsOutputDir(String hdfsOutputDir) {
+    public ApplicationConfig hdfsOutputDir(String hdfsOutputDir) {
         this.hdfsOutputDir = hdfsOutputDir;
+        return this;
+    }
+
+    public Map<String, String> getSourceTypeConnectionTimeout() {
+        return sourceTypeConnectionTimeout;
+    }
+
+    public ApplicationConfig sourceTypeConnectionTimeout(Map<String, String> sourceTypeTimeout) {
+        this.sourceTypeConnectionTimeout = sourceTypeTimeout;
+        return this;
     }
 }

--- a/src/main/java/org/radarcns/domain/restapi/Source.java
+++ b/src/main/java/org/radarcns/domain/restapi/Source.java
@@ -24,7 +24,7 @@ public class Source {
     private Boolean assigned;
 
     @JsonProperty
-    private String status;
+    private SourceStatus status;
 
     @JsonProperty
     private TimeFrame effectiveTimeFrame;
@@ -107,12 +107,12 @@ public class Source {
     }
 
 
-    public Source status(String status) {
+    public Source status(SourceStatus status) {
         this.status = status;
         return this;
     }
 
-    public String getStatus() {
+    public SourceStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/org/radarcns/domain/restapi/SourceState.java
+++ b/src/main/java/org/radarcns/domain/restapi/SourceState.java
@@ -1,5 +1,0 @@
-package org.radarcns.domain.restapi;
-
-public enum SourceState {
-    FINE, OK, WARNING, DISCONNECTED, UNKNOWN
-}

--- a/src/main/java/org/radarcns/domain/restapi/SourceStatus.java
+++ b/src/main/java/org/radarcns/domain/restapi/SourceStatus.java
@@ -1,0 +1,5 @@
+package org.radarcns.domain.restapi;
+
+public enum SourceStatus {
+    CONNECTED, OK, WARNING, DISCONNECTED, UNKNOWN
+}

--- a/src/main/java/org/radarcns/service/SourceService.java
+++ b/src/main/java/org/radarcns/service/SourceService.java
@@ -1,6 +1,8 @@
 package org.radarcns.service;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,7 +10,10 @@ import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 import org.radarcns.catalog.SourceCatalog;
 import org.radarcns.domain.managementportal.MinimalSourceDetailsDTO;
+import org.radarcns.domain.managementportal.SourceDTO;
 import org.radarcns.domain.managementportal.SourceTypeDTO;
+import org.radarcns.domain.restapi.Source;
+import org.radarcns.domain.restapi.SourceStatus;
 import org.radarcns.domain.restapi.header.TimeFrame;
 import org.radarcns.listener.managementportal.ManagementPortalClient;
 import org.slf4j.Logger;
@@ -23,6 +28,8 @@ public class SourceService {
     private final SourceCatalog sourceCatalog;
 
     private final ManagementPortalClient managementPortalClient;
+
+    private static final Duration DEFAULT_SOURCE_CONNECTION_TIMEOUT = Duration.ofHours(6);
 
     /**
      * Default constructor. Injects all dependencies for the class.
@@ -48,7 +55,7 @@ public class SourceService {
      * @param sources from MP
      * @return list of sources assigned to subject under given project.
      */
-    private List<org.radarcns.domain.restapi.Source> buildSourcesFromMinimal(String projectId,
+    private List<Source> buildSourcesFromMinimal(String projectId,
             String subjectId, Collection<MinimalSourceDetailsDTO> sources) {
         return sources.stream().map(p -> buildSource(projectId, subjectId, p)).collect(Collectors
                 .toList());
@@ -63,7 +70,7 @@ public class SourceService {
      * @param source instance from MP
      * @return computed Source.
      */
-    private org.radarcns.domain.restapi.Source buildSource(String projectId, String subjectId,
+    private Source buildSource(String projectId, String subjectId,
             MinimalSourceDetailsDTO source) {
         SourceTypeDTO sourceType;
         // a source fetched from MP should ideally have a source-type
@@ -78,16 +85,87 @@ public class SourceService {
                     "Cannot retrieve sourceType for given sourceType " + source.getSourceId());
         }
 
-        return new org.radarcns.domain.restapi.Source()
+        TimeFrame effectiveTimeFrame = this.sourceMonitorService
+                .getEffectiveTimeFrame(projectId, subjectId,
+                        source.getSourceId().toString(), sourceType);
+        return new Source()
                 .sourceId(source.getSourceId().toString())
                 .assigned(source.isAssigned())
                 .sourceName(source.getSourceName())
                 .sourceTypeCatalogVersion(source.getSourceTypeCatalogVersion())
                 .sourceTypeProducer(source.getSourceTypeProducer())
                 .sourceTypeModel(source.getSourceTypeModel())
-                .effectiveTimeFrame(this.sourceMonitorService
-                        .getEffectiveTimeFrame(projectId, subjectId,
-                                source.getSourceId().toString(), sourceType));
+                .effectiveTimeFrame(effectiveTimeFrame)
+                .status(getSourceStatus(source.getSourceTypeProducer(), source
+                        .getSourceTypeModel(), effectiveTimeFrame));
+    }
+
+    /**
+     * Build a {@link org.radarcns.domain.restapi.Source} using provided parameters and by
+     * calculating TimeFrame of the source.
+     *
+     * @param projectId of subject
+     * @param subjectId of subject
+     * @param source instance from MP
+     * @return computed Source.
+     */
+    private Source buildSource(String projectId, String subjectId,
+            SourceDTO source) {
+        SourceTypeDTO sourceType;
+        // a source fetched from MP should ideally have a source-type
+        try {
+            sourceType = this.sourceCatalog.getSourceType(source
+                    .getSourceType().getProducer(), source.getSourceType().getModel(), source
+                    .getSourceType().getCatalogVersion());
+        } catch (NotFoundException | IOException e) {
+            LOGGER.error(
+                    "Cannot retrieve sourceType for given sourceType " + source.getSourceId());
+            throw new IllegalStateException(
+                    "Cannot retrieve sourceType for given sourceType " + source.getSourceId());
+        }
+
+        TimeFrame effectiveTimeFrame = this.sourceMonitorService
+                .getEffectiveTimeFrame(projectId, subjectId,
+                        source.getSourceId(), sourceType);
+        return new Source()
+                .sourceId(source.getSourceId())
+                .assigned(source.getAssigned())
+                .sourceName(source.getSourceName())
+                .sourceTypeCatalogVersion(sourceType.getCatalogVersion())
+                .sourceTypeProducer(sourceType.getProducer())
+                .sourceTypeModel(sourceType.getModel())
+                .effectiveTimeFrame(effectiveTimeFrame)
+                .status(getSourceStatus(sourceType.getProducer(), sourceType.getModel(),
+                        effectiveTimeFrame));
+    }
+
+    /**
+     * Computes the status of a source based on the last seen of the source and
+     * connection-timeout specified for source-type or using default value. Returns
+     * {@link SourceStatus#CONNECTED} is the effectiveTimeFrame.endTime is not earlier than
+     * timeout duration from now.
+     * @param producer of source-type
+     * @param model of source-type
+     * @param effectiveTimeFrame of the source
+     * @return computed source status
+     */
+    private SourceStatus getSourceStatus(String producer, String model,
+            TimeFrame effectiveTimeFrame) {
+        if (effectiveTimeFrame != null && effectiveTimeFrame.getEndDateTime() != null) {
+            // convert to lower case to produce key
+            String sourceTypeKey = (producer + "_" + model).toLowerCase();
+            Duration timeout = DEFAULT_SOURCE_CONNECTION_TIMEOUT;
+            if (org.radarcns.config.Properties.getApiConfig().getSourceTypeConnectionTimeout()
+                    .containsKey(sourceTypeKey)) {
+                // use configured timeout if specified
+                timeout = Duration.parse(org.radarcns.config.Properties.getApiConfig()
+                        .getSourceTypeConnectionTimeout().get(sourceTypeKey));
+            }
+            return (Instant.now().minus(timeout).isBefore(effectiveTimeFrame.getEndDateTime()))
+                    ? SourceStatus.CONNECTED : SourceStatus.DISCONNECTED;
+        }
+        // status UNKNOWN if the effective-time is not available
+        return SourceStatus.UNKNOWN;
     }
 
     /**
@@ -97,11 +175,15 @@ public class SourceService {
      * @param subjectId of subject
      * @return list of {@link org.radarcns.domain.restapi.Source} of subject
      */
-    public List<org.radarcns.domain.restapi.Source> getAllSourcesOfSubject(String projectName,
+    public List<Source> getAllSourcesOfSubject(String projectName,
             String subjectId) throws IOException {
         //TODO implement fetching all recorded sources for subject
         return buildSourcesFromMinimal(projectName, subjectId,
                 this.managementPortalClient.getSubject(subjectId).getSources());
     }
 
+    public Source getSourceBySourceId(String projectName, String subjectId, String sourceId)
+            throws IOException {
+        return buildSource(projectName, subjectId, this.managementPortalClient.getSource(sourceId));
+    }
 }

--- a/src/main/java/org/radarcns/webapp/resource/SourceEndPoint.java
+++ b/src/main/java/org/radarcns/webapp/resource/SourceEndPoint.java
@@ -77,22 +77,21 @@ public class SourceEndPoint {
     public List<Source> getAllSourcesJson(
             @Alphanumeric @PathParam(PROJECT_NAME) String projectName,
             @Alphanumeric @PathParam(SUBJECT_ID) String subjectId) throws IOException {
-        managementPortalClient.getProject(projectName);
         managementPortalClient.checkSubjectInProject(projectName, subjectId);
         return sourceService.getAllSourcesOfSubject(projectName, subjectId);
     }
 
     //------------------------------------------------------------------------------------------//
-    //                                       STATE FUNCTIONS                                    //
+    //                                       SOURCE BY ID FUNCTIONS                             //
     //------------------------------------------------------------------------------------------//
 
     /**
-     * JSON function that returns the status of the given source.
+     * JSON function that returns the source of the given source-id.
      */
     @GET
     @Produces({APPLICATION_JSON, AVRO_BINARY})
     @Path("/{" + PROJECT_NAME + "}" + "/" + SUBJECTS + "/{" + SUBJECT_ID + "}" + "/" + SOURCES
-            + "}/{" + SOURCE_ID + "}")
+            + "/{" + SOURCE_ID + "}")
     @Operation(summary = "Return a source requested")
     @ApiResponse(responseCode = "500", description = "An error occurs while executing")
     @ApiResponse(responseCode = "200", description = "Return a source object containing last"
@@ -104,10 +103,10 @@ public class SourceEndPoint {
     public Source getLastComputedSourceStatusJson(
             @Alphanumeric @PathParam(PROJECT_NAME) String projectName,
             @Alphanumeric @PathParam(SUBJECT_ID) String subjectId,
-            @Alphanumeric @PathParam(SOURCE_ID) String sourceId) {
+            @Alphanumeric @PathParam(SOURCE_ID) String sourceId) throws IOException {
 
-        // TODO implement source-summary calculation which includes the compliance
-        return new Source();
+        managementPortalClient.checkSubjectInProject(projectName, subjectId);
+        return sourceService.getSourceBySourceId(projectName, subjectId, sourceId);
     }
 
 }


### PR DESCRIPTION
Compute source status from `effectiveTimeFrame.endTimeStamp` of a source and `source-type-connnection-timeout` if configured for corresponding source-type. Otherwise it would use the default connection timeout.

Closes #48 