### PR TITLE
add file_glob to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,9 @@ after_script:
 deploy:
   provider: releases
   api_key: ${GH_TOKEN}
+  file_glob: true
   file:
-    - "build/libs/radar-restapi-*.jar"
+    - "build/libs/*.jar"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
`file_glob` is necessary to enable  wildcards 