### PR TITLE
fix null pointer when effectiveTimeFrame is not available.

### DIFF
--- a/src/integrationTest/java/org/radarcns/webapp/SubjectEndPointTest.java
+++ b/src/integrationTest/java/org/radarcns/webapp/SubjectEndPointTest.java
@@ -19,6 +19,7 @@ package org.radarcns.webapp;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.radarcns.domain.restapi.SourceStatus.CONNECTED;
 import static org.radarcns.integration.util.ExpectedDocumentFactory.getDocumentsForStatistics;
@@ -96,6 +97,17 @@ public class SubjectEndPointTest {
         assertNotNull(apiClient.get(
                 BasePath.PROJECTS + '/' + PROJECT + '/' + SUBJECTS + "/OTHER",
                 APPLICATION_JSON, Status.NOT_FOUND));
+    }
+
+    @Test
+    public void getSubjectsByProjectName200WhenNoSourceStatisticsAvailable() throws IOException {
+        List<Subject> subjects = apiClient.getJsonList(
+                BasePath.PROJECTS + '/' + PROJECT + '/' + SUBJECTS,
+                Subject.class, Status.OK);
+        assertNotNull(subjects);
+        assertTrue(subjects.size() > 0);
+        assertEquals(PROJECT, subjects.get(0).getProject());
+        assertNull(subjects.get(0).getLastSeen());
     }
 
     private void insertMonitorStatistics(Instant startTime, Instant end) {

--- a/src/main/java/org/radarcns/service/SubjectService.java
+++ b/src/main/java/org/radarcns/service/SubjectService.java
@@ -73,7 +73,8 @@ public class SubjectService {
 
     private Instant getLastSeenForSubject(List<Source> sources) {
         return sources.stream()
-                .map(s -> s.getEffectiveTimeFrame().getEndDateTime())
+                .map(s -> s.getEffectiveTimeFrame() != null
+                        ? s.getEffectiveTimeFrame().getEndDateTime() : null)
                 .filter(Objects::nonNull)
                 .reduce((i1, i2) -> i1.isAfter(i2) ? i1 : i2)
                 .orElse(null);


### PR DESCRIPTION
When we don't have any records from source-statistics-monitor for a source , the `effectiveTimeFrame` is null and the status is `UNKNOWN`. If the `effectiveTimeFrame` is not found return `null` as the value  of `LastSeen` of a subject. 

Fixes #97 